### PR TITLE
Add two links to the BigQuery vignette.

### DIFF
--- a/inst/doc/BigQueryDemo.Rmd
+++ b/inst/doc/BigQueryDemo.Rmd
@@ -26,6 +26,10 @@ Google Genomics can import variant calls from VCF files or Complete Genomics mas
 
 In this example we will work with the [Illumina Platinum Genomes](http://googlegenomics.readthedocs.org/en/latest/use_cases/discover_public_data/platinum_genomes.html) dataset.
 
+### Helpful BigQuery links
+
+For this example, we'll also be working with [Google BigQuery](https://cloud.google.com/bigquery/). It's often helpful to have a [link to the docs](https://cloud.google.com/bigquery/what-is-bigquery) handy, and especially the [query reference](https://cloud.google.com/bigquery/query-reference).
+
 ## Run a query from R
 
 The [bigrquery](https://github.com/hadley/bigrquery) package written by Hadley Wickham implements an R interface to [Google BigQuery](https://cloud.google.com/bigquery/).


### PR DESCRIPTION
There are other useful ones for people using the API directly, but I think these cover what most genomics users are likely to need.

PTAL @deflaux 